### PR TITLE
Use Time.time instead of DateTime.Now to prevent a hiccup on first le…

### DIFF
--- a/Assets/ScrollSnap.cs
+++ b/Assets/ScrollSnap.cs
@@ -27,7 +27,7 @@ public class ScrollSnap : UIBehaviour, IDragHandler, IEndDragHandler {
 	Vector2 cellSize;
 	bool indexChangeTriggered = false;
 	bool isLerping = false;
-	DateTime lerpStartedAt;
+	float lerpStartedAt;
 	Vector2 releasedPosition;
 	Vector2 targetPosition;
 
@@ -172,7 +172,7 @@ public class ScrollSnap : UIBehaviour, IDragHandler, IEndDragHandler {
 	void StartLerping() {
 		releasedPosition = content.anchoredPosition;
 		targetPosition = CalculateTargetPoisition(cellIndex);
-		lerpStartedAt = DateTime.Now;
+		lerpStartedAt = Time.time;
 		canvasGroup.blocksRaycasts = false;
 		isLerping = true;
 	}
@@ -195,7 +195,7 @@ public class ScrollSnap : UIBehaviour, IDragHandler, IEndDragHandler {
 	}
 
 	void LerpToElement() {
-		float t = (float)((DateTime.Now - lerpStartedAt).TotalMilliseconds / lerpTimeMilliSeconds);
+        float t = (float)((Time.time - lerpStartedAt) * 1000 / lerpTimeMilliSeconds);
 		float newX = Mathf.Lerp(releasedPosition.x, targetPosition.x, t);
 		content.anchoredPosition = new Vector2(newX, content.anchoredPosition.y);
 	}

--- a/Assets/ScrollSnap.cs
+++ b/Assets/ScrollSnap.cs
@@ -195,7 +195,7 @@ public class ScrollSnap : UIBehaviour, IDragHandler, IEndDragHandler {
 	}
 
 	void LerpToElement() {
-        float t = (float)((Time.time - lerpStartedAt) * 1000 / lerpTimeMilliSeconds);
+		float t = (float)((Time.time - lerpStartedAt) * 1000 / lerpTimeMilliSeconds);
 		float newX = Mathf.Lerp(releasedPosition.x, targetPosition.x, t);
 		content.anchoredPosition = new Vector2(newX, content.anchoredPosition.y);
 	}

--- a/Assets/ScrollSnap.cs
+++ b/Assets/ScrollSnap.cs
@@ -195,7 +195,7 @@ public class ScrollSnap : UIBehaviour, IDragHandler, IEndDragHandler {
 	}
 
 	void LerpToElement() {
-		float t = (float)((Time.time - lerpStartedAt) * 1000 / lerpTimeMilliSeconds);
+		float t = (Time.time - lerpStartedAt) * 1000 / lerpTimeMilliSeconds;
 		float newX = Mathf.Lerp(releasedPosition.x, targetPosition.x, t);
 		content.anchoredPosition = new Vector2(newX, content.anchoredPosition.y);
 	}


### PR DESCRIPTION
First call of DateTime.Now can be slow on mobile devices can and this is by design.
Please take a look at the following link:

https://issuetracker.unity3d.com/issues/ios-il2cpp-system-dot-datetime-dot-now-is-slow-on-the-first-run

Replaced DateTime.Now with Time.time, to prevent a hiccup on first Lerp on mobile devices.
Works the same way! :)

